### PR TITLE
Syntax Error caused by unecessary trailing commas

### DIFF
--- a/src/functions/AnalyzePendingTweet/index.js
+++ b/src/functions/AnalyzePendingTweet/index.js
@@ -53,7 +53,7 @@ function saveToGraph(tweets) {
         queries.push(constructAddEdgeString(
             'tweeted',
             { label: 'user', id: tweet.user },
-            { label: 'tweet', id: tweet.id },
+            { label: 'tweet', id: tweet.id }
         ));
 
         if (isIterable(tweet.hashtags)) {
@@ -61,7 +61,7 @@ function saveToGraph(tweets) {
                 queries.push(constructAddEdgeString(
                     'contains',
                     { label: 'tweet', id: tweet.id },
-                    { label: 'hashtag', id: hashtag },
+                    { label: 'hashtag', id: hashtag }
                 ));
             }
         }


### PR DESCRIPTION
When debugging the AnalyzePendingTweet function locally I was getting the error `SyntaxError: Unexpected token )`


```
[3/4/2018 8:18:57 PM]   Function had errors. See Azure WebJobs SDK dashboard for details. Instance ID is 'dc37ab8e-f7f9-4e98-be09-dd61a3bd6204'
[3/4/2018 8:18:57 PM] mscorlib: Exception while executing function: Functions.AnalyzePendingTweet. mscorlib: One or more errors occurred. C:\src\SmartHotel360-Sentiment-Analysis-App\src\functions\AnalyzePendingTweet\index.js:57
        ));
        ^

SyntaxError: Unexpected token )
    at createScript (vm.js:56:10)
    at Object.runInThisContext (vm.js:97:10)
    at Module._compile (module.js:542:28)
    at Object.Module._extensions..js (module.js:579:10)
    at Module.load (module.js:487:32)
    at tryModuleLoad (module.js:446:12)
    at Function.Module._load (module.js:438:3)
    at Module.require (module.js:497:17)
    at require (internal/module.js:20:19)
    at eval (eval at compileFunc (C:\Users\snoll\AppData\Roaming\npm\node_modules\azure-functions-core-tools\bin\edge\double_edge.js:34:28), <anonymous>:1:80)
    at compileFunc (C:\Users\snoll\AppData\Roaming\npm\node_modules\azure-functions-core-tools\bin\edge\double_edge.js:35:16).
```
Removing the trailing comma's @ [index.js:ln56](https://github.com/Microsoft/SmartHotel360-Sentiment-Analysis-App/blob/master/src/functions/AnalyzePendingTweet/index.js#L56) and [index.js:ln64](https://github.com/Microsoft/SmartHotel360-Sentiment-Analysis-App/blob/master/src/functions/AnalyzePendingTweet/index.js#L64) resolved the issue.